### PR TITLE
Allow to use any word number in WP CLI

### DIFF
--- a/wp-cli.sh
+++ b/wp-cli.sh
@@ -1,9 +1,3 @@
 #!/usr/bin/sh
 
-if [ "$#" -ne 1 ]; then
-  echo ""
-  echo "Usage: $0 \"wp-cli command here\"" >&2
-  exit 1
-fi
-
-docker-compose run --rm wp-cli $1
+docker-compose run --rm wp-cli $*


### PR DESCRIPTION
WP CLI allows to use commands which contain any number of words. See `wp help post` for example:

    # Create a new post.
    $ wp post create --post_type=post --post_title='A sample post'
    Success: Created post 123.

    # Update an existing post.
    $ wp post update 123 --post_status=draft
    Success: Updated post 123.

    # Delete an existing post.
    $ wp post delete 123
    Success: Trashed post 123.

Let's remove constrain and transmit all parameters `$*` instead of first one `$1`:
```
$ ./wp-cli.sh post list
Starting wordpress-installer_mysql_1 ... done
Starting wordpress-installer_wordpress_1 ... done
+----+--------------+-------------+---------------------+-------------+
| ID | post_title   | post_name   | post_date           | post_status |
+----+--------------+-------------+---------------------+-------------+
| 1  | Hello world! | hello-world | 2022-11-22 22:20:54 | publish     |
+----+--------------+-------------+---------------------+-------------+
$ ./wp-cli.sh
Starting wordpress-installer_mysql_1 ... done
Starting wordpress-installer_wordpress_1 ... done
wp>
```

We can type some PHP expression after `wp>` prompt and then exit with **Ctrl+D** shortcut:

```
wp>explode(' ', 'This is PHP console')
=> array(4) {
  [0]=>
  string(4) "This"
  [1]=>
  string(2) "is"
  [2]=>
  string(3) "PHP"
  [3]=>
  string(7) "console"
}
wp> 
```

As we can see now, any number of words, including 0, 2 and more, are useful.